### PR TITLE
Closes #9. Gradle to pass relevant system properties into the dynamometer-infra test task.

### DIFF
--- a/dynamometer-infra/build.gradle
+++ b/dynamometer-infra/build.gradle
@@ -16,3 +16,11 @@ dependencies {
   testCompile 'junit:junit:4.11'
   testCompile 'org.mockito:mockito-all:1.10.19'
 }
+
+test {
+  [ "dyno.apache-mirror", "dyno.hadoop.bin.path", "dyno.hadoop.bin.version" ].each {
+    if (System.getProperty(it) != null) {
+      systemProperty it, System.getProperty(it)
+    }
+  }
+}


### PR DESCRIPTION
Tested to confirm that this properly allows passing the specified properties like:
```
gradle :dynamometer-infra:test -Dsystem.property=value
```