### PR TITLE
Closes #16. Use a single shared queue between all threads in each workload mapper.

### DIFF
--- a/dynamometer-workload/src/main/java/com/linkedin/dynamometer/workloadgenerator/audit/AuditReplayMapper.java
+++ b/dynamometer-workload/src/main/java/com/linkedin/dynamometer/workloadgenerator/audit/AuditReplayMapper.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.DelayQueue;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -121,6 +122,7 @@ public class AuditReplayMapper extends WorkloadMapper<LongWritable, Text> {
   private int numThreads;
   private long highestTimestamp;
   private List<AuditReplayThread> threads;
+  private DelayQueue<AuditReplayCommand> commandQueue;
   private Function<Long, Long> relativeToAbsoluteTimestamp;
   private AuditCommandParser commandParser;
 
@@ -172,8 +174,9 @@ public class AuditReplayMapper extends WorkloadMapper<LongWritable, Text> {
     LOG.info("Starting " + numThreads + " threads");
 
     threads = new ArrayList<>();
+    commandQueue = new DelayQueue<>();
     for (int i = 0; i < numThreads; i++) {
-      AuditReplayThread thread = new AuditReplayThread(context);
+      AuditReplayThread thread = new AuditReplayThread(context, commandQueue);
       threads.add(thread);
       thread.start();
     }
@@ -188,11 +191,7 @@ public class AuditReplayMapper extends WorkloadMapper<LongWritable, Text> {
     if (delay > MAX_READAHEAD_MS) {
       Thread.sleep(delay - (MAX_READAHEAD_MS / 2));
     }
-    int idx = cmd.getSrc().hashCode() % numThreads;
-    if (idx < 0) {
-      idx += numThreads;
-    }
-    threads.get(idx).addToQueue(cmd);
+    commandQueue.put(cmd);
     highestTimestamp = cmd.getAbsoluteTimestamp();
   }
 

--- a/dynamometer-workload/src/main/java/com/linkedin/dynamometer/workloadgenerator/audit/AuditReplayThread.java
+++ b/dynamometer-workload/src/main/java/com/linkedin/dynamometer/workloadgenerator/audit/AuditReplayThread.java
@@ -61,8 +61,9 @@ public class AuditReplayThread extends Thread {
   private Map<REPLAYCOUNTERS, Counter> replayCountersMap = new HashMap<>();
   private Map<String, Counter> individualCommandsMap = new HashMap<>();
 
-  AuditReplayThread(Mapper.Context mapperContext) throws IOException {
-    commandQueue = new DelayQueue<>();
+  AuditReplayThread(Mapper.Context mapperContext, DelayQueue<AuditReplayCommand> queue)
+      throws IOException {
+    commandQueue = queue;
     Configuration mapperConf = mapperContext.getConfiguration();
     String namenodeURI = mapperConf.get(WorkloadDriver.NN_URI);
     startTimestampMs = mapperConf.getLong(WorkloadDriver.START_TIMESTAMP_MS, -1);


### PR DESCRIPTION
On a single mapper in the workload replay, currently tasks are distributed to threads in a path-partitioned manner. This results in bad skew issues, where one thread can fall very far behind because it is overloaded. Thus, although all of the issues on a specific path get executed in order (though late), the ordering with other paths is very far out of sync. It is better to let some operations on the same path occur out of order so that (a) overall everything stays more in sync and (b) no thread falls far behind (which can delay the entire mapper from completing).