### PR TITLE
Fix start-workload.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ via logging when the Dyno-NN has exited safemode and is ready for use.
 At this point, a workload job (map-only MapReduce job) can be launched, e.g.:
 ```
 ./bin/start-workload.sh
-    -Dauditreplay.input-path hdfs:///dyno/audit_logs/
-    -Dauditreplay.num-threads 50
+    -Dauditreplay.input-path=hdfs:///dyno/audit_logs/
+    -Dauditreplay.num-threads=50
     -nn_uri hdfs://namenode_address:port/
     -start_time_offset 5m
     -mapper_class_name AuditReplayMapper

--- a/dynamometer-workload/src/main/java/com/linkedin/dynamometer/workloadgenerator/WorkloadDriver.java
+++ b/dynamometer-workload/src/main/java/com/linkedin/dynamometer/workloadgenerator/WorkloadDriver.java
@@ -141,7 +141,7 @@ public class WorkloadDriver extends Configured implements Tool {
 
   private Class<? extends WorkloadMapper> getMapperClass(String className) throws ClassNotFoundException {
     if (!className.contains(".")) {
-      className = WorkloadDriver.class.getPackage().getName() + "." + className;
+      className = WorkloadDriver.class.getPackage().getName() + ".audit." + className;
     }
     Class<?> mapperClass = getConf().getClassByName(className);
     if (!WorkloadMapper.class.isAssignableFrom(mapperClass)) {


### PR DESCRIPTION
This fixes two issues encountered when running start-workload.sh:

1. The README description is incorrect. It should use `=` for
   config key & value for auditreplay configs.
2. The mapper_class_name value doesn't work - it should look under
   com.linkedin.dynamometer.workloadgenerator.audit instead of
   com.linkedin.dynamometer.workloadgenerator

Fixes #60 .