### PR TITLE
Add the ability to specify additional dependencies for containers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ subprojects {
   apply plugin: 'idea'
   apply plugin: 'license'
 
-  sourceCompatibility = 1.7
+  sourceCompatibility = 1.8
 
   license {
     header rootProject.file('license_header')

--- a/dynamometer-infra/src/main/java/com/linkedin/dynamometer/ApplicationMaster.java
+++ b/dynamometer-infra/src/main/java/com/linkedin/dynamometer/ApplicationMaster.java
@@ -689,7 +689,7 @@ public class ApplicationMaster {
       addAsLocalResourceFromEnv(DynoConstants.START_SCRIPT, localResources, envs);
       addAsLocalResourceFromEnv(DynoConstants.HADOOP_BINARY, localResources, envs);
       addAsLocalResourceFromEnv(DynoConstants.VERSION, localResources, envs);
-      addAsLocalResourceFromEnv(DynoConstants.DYNO_JAR, localResources, envs);
+      addAsLocalResourceFromEnv(DynoConstants.DYNO_DEPENDENCIES, localResources, envs);
       if (isNameNodeLauncher) {
         addAsLocalResourceFromEnv(DynoConstants.FS_IMAGE, localResources, envs);
         addAsLocalResourceFromEnv(DynoConstants.FS_IMAGE_MD5, localResources, envs);

--- a/dynamometer-infra/src/main/java/com/linkedin/dynamometer/DynoConstants.java
+++ b/dynamometer-infra/src/main/java/com/linkedin/dynamometer/DynoConstants.java
@@ -39,8 +39,8 @@ public class DynoConstants {
   public static final DynoResource FS_IMAGE_MD5 = new DynoResource("FS_IMAGE_MD5", FILE, null);
   // Resource for the VERSION file accompanying the file system image
   public static final DynoResource VERSION = new DynoResource("VERSION", FILE, "VERSION");
-  // Resource for the JAR file containing all of the Dynamometer Java code
-  public static final DynoResource DYNO_JAR = new DynoResource("DYNO_JAR", FILE, "dynamometer.jar");
+  // Resource for the archive containing all dependencies
+  public static final DynoResource DYNO_DEPENDENCIES = new DynoResource("DYNO_DEPS", ARCHIVE, "dependencies");
 
   // Environment variable which will contain the location of the directory
   // which holds all of the block files for the DataNodes

--- a/dynamometer-infra/src/main/resources/start-component.sh
+++ b/dynamometer-infra/src/main/resources/start-component.sh
@@ -96,7 +96,7 @@ export HADOOP_CONF_DIR=${confDir}
 export YARN_CONF_DIR=${confDir}
 export HADOOP_LOG_DIR=${logDir}
 export HADOOP_PID_DIR=${pidDir}
-export HADOOP_CLASSPATH="$extraClasspathDir"
+export HADOOP_CLASSPATH="`pwd`/dependencies/*:$extraClasspathDir"
 echo "Environment variables are set as:"
 echo "(note that this doesn't include changes made by hadoop-env.sh)"
 printenv
@@ -179,10 +179,9 @@ if [ "$component" = "datanode" ]; then
 EOF
 
   echo "Executing the following:"
-  printf "${HADOOP_HOME}/bin/hadoop jar dynamometer.jar com.linkedin.dynamometer.SimulatedDataNodes "
+  printf "${HADOOP_HOME}/bin/hadoop com.linkedin.dynamometer.SimulatedDataNodes "
   printf "$DN_ADDITIONAL_ARGS $datanodeClusterConfigs\n"
-  ${HADOOP_HOME}/bin/hadoop jar dynamometer.jar com.linkedin.dynamometer.SimulatedDataNodes \
-    $DN_ADDITIONAL_ARGS $datanodeClusterConfigs &
+  ${HADOOP_HOME}/bin/hadoop com.linkedin.dynamometer.SimulatedDataNodes $DN_ADDITIONAL_ARGS $datanodeClusterConfigs &
   launchSuccess="$?"
   componentPID="$!"
   if [[ ${launchSuccess} -ne 0 ]]; then
@@ -245,9 +244,6 @@ EOF
   ln -snf "`pwd`/$fsImageMD5File" "$nameDir/current/$fsImageMD5File"
   ln -snf "`pwd`/VERSION" "$nameDir/current/VERSION"
   chmod 700 "$nameDir/current/"*
-
-  # To be able to use the custom block placement policy and the AllowAllImpersonationProvider
-  export HADOOP_CLASSPATH="`pwd`/dynamometer.jar:$HADOOP_CLASSPATH"
 
  read -r -d '' namenodeConfigs <<EOF
   -D fs.defaultFS=hdfs://${nnHostname}:${nnRpcPort}

--- a/dynamometer-infra/src/test/java/com/linkedin/dynamometer/TestDynamometerInfra.java
+++ b/dynamometer-infra/src/test/java/com/linkedin/dynamometer/TestDynamometerInfra.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.yarn.util.resource.DominantResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 


### PR DESCRIPTION
Currently, the only Java dependency that is distributed to the containers is the dynamometer-infra.jar containing the Application Master. We may need to support arbitrary dependencies in the future, and in particular, Hadoop 3 support will require distributing the JUnit JAR to containers because MiniDFSCluster relies on JUnit. Add in generic support for dependencies, instead of the current method of assuming there is only a single JAR needed.