### PR TITLE
Clean up MiniYARNCluster setup to not use fixed ports

### DIFF
--- a/dynamometer-infra/src/test/java/com/linkedin/dynamometer/TestDynamometerInfra.java
+++ b/dynamometer-infra/src/test/java/com/linkedin/dynamometer/TestDynamometerInfra.java
@@ -188,8 +188,9 @@ public class TestDynamometerInfra {
       throw new RuntimeException("Could not find 'yarn-site.xml' dummy file in classpath");
     }
     yarnConf.set(YarnConfiguration.YARN_APPLICATION_CLASSPATH, new File(url.getPath()).getParent());
-    // Write the XML to a buffer before writing to the file, since the XML dump can cause the
-    // yarn-site.xml file to be read
+    // Write the XML to a buffer before writing to the file. writeXml() can trigger a read of the existing
+    // yarn-site.xml, so writing directly could trigger a read of the file while it is in an inconsistent state
+    // (partially written)
     try (ByteArrayOutputStream bytesOut = new ByteArrayOutputStream()) {
       yarnConf.writeXml(bytesOut);
       try (OutputStream fileOut = new FileOutputStream(new File(url.getPath()))) {

--- a/dynamometer-infra/src/test/resources/yarn-site.xml
+++ b/dynamometer-infra/src/test/resources/yarn-site.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+
+    Copyright 2019 LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+    See LICENSE in the project root for license information.
+
+-->
+
+<configuration>
+  <!-- Dummy (invalid) config file to be overwritten by tests with MiniCluster configuration. -->
+</configuration>


### PR DESCRIPTION
The existing tests relied on a MiniYARNCluster that used fixed ports for the YarnClient to know how to communicate with it. Following the example of `TestDistributedShell`, it's possible to do this without fixed ports, which helps the test to be more robust.