### PR TITLE
Fix State transition err when hdfs ccm feature is used

### DIFF
--- a/dynamometer-blockgen/src/main/java/com/linkedin/dynamometer/blockgenerator/XMLParser.java
+++ b/dynamometer-blockgen/src/main/java/com/linkedin/dynamometer/blockgenerator/XMLParser.java
@@ -52,6 +52,16 @@ class XMLParser {
    * @return {@code BlockInfo}s for any blocks found.
    */
   List<BlockInfo> parseLine(String line) throws IOException {
+    // Centralized Cache Management compatibility
+    // if CCM feature is open, fsimage xml may include
+    // <directive><id>8963</id><path>/user/some/path</path><replication>3</replication>
+    // <pool>cache_other_pool</pool><expiration><millis>1544454142310</millis><relatilve>false</relatilve></expiration>
+    // these lines need to be filtered
+    if (line.contains("<directive><id>")) {
+      System.out.println("this line is for Centralized Cache Management, ignore, line:" + line);
+      return new ArrayList<>();
+    }
+
     if (line.contains("<inode>")) {
       transitionTo(State.INODE);
     }


### PR DESCRIPTION
When we used dynamometer to test HDFS performance, the test encountered a error when generate DataNode Block info. The error stack is
`Error: java.io.IOException: State transition not allowed; from DEFAULT to FILE_WITH_REPLICATION
        at com.linkedin.dynamometer.blockgenerator.XMLParser.transitionTo(XMLParser.java:107)
        at com.linkedin.dynamometer.blockgenerator.XMLParser.parseLine(XMLParser.java:77)
        at com.linkedin.dynamometer.blockgenerator.XMLParserMapper.map(XMLParserMapper.java:53)
        at com.linkedin.dynamometer.blockgenerator.XMLParserMapper.map(XMLParserMapper.java:26)
        at org.apache.hadoop.mapreduce.Mapper.run(Mapper.java:151)
        at org.apache.hadoop.mapred.MapTask.runNewMapper(MapTask.java:828)
        at org.apache.hadoop.mapred.MapTask.run(MapTask.java:341)
        at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:174)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:415)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1690)
        at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:168)`

After checking Fsimage xml and the source code, we find that **XMLParser** can not parse the lines correctly, these lines are like
`<directive><id>8963</id><path>/user/somepath/path1</path><replication>3</replication><pool>cache_other_pool</pool><expiration><millis>1544454142310</millis><relatilve>false</relatilve></expiration>
<directive><id>8964</id><path>/user/somepath/path2</path><replication>3</replication><pool>cache_hadoop-data_pool</pool><expiration><millis>1544497817686</millis><relatilve>false</relatilve></expiration>
<directive><id>8965</id><path>/user/somepath/path3</path><replication>3</replication><pool>cache_hadoop-peisong_pool</pool><expiration><millis>1544451500312</millis><relatilve>false</relatilve></expiration>
<directive><id>8967</id><path>/user/somepath/path4</path><replication>3</replication><pool>cache_other_pool</pool><expiration><millis>1544497602570</millis><relatilve>false</relatilve></expiration>`

These fsimage xml lines are generated when [HDFS Centralized Cache Management (CCM)](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/CentralizedCacheManagement.html) feature is used.

So we add a patch to ignore the CCM fsimage xml lines when parsing xml.