### PR TITLE
Update parse start script to handle the case that fsimage txid is cov…

### DIFF
--- a/dynamometer-workload/src/main/bash/parse-start-timestamp.sh
+++ b/dynamometer-workload/src/main/bash/parse-start-timestamp.sh
@@ -27,8 +27,8 @@ fi
 
 # try to find the edit logs whose transaction range covers the txid from the fsimage
 # first find the first txid which is greater or equal to the fsimage txid
-ending_txid=`ls -1 ${edits_dir} | grep -E "^edits_[[:digit:]]+-[[:digit:]]+\$" | cut -d'-' -f 2 | \
-    awk -v t="$image_txid" {'if ($1 >= t) {print $1}'} | head -1`
+ending_txid=`ls -1 ${edits_dir} | grep -E "^edits_[[:digit:]]+-[[:digit:]]+\$" | \
+    awk -v t="$tmp_txid" -F'-' '{if ($2 >= t) {print $2}}' | head -1`
 if [ -z "$ending_txid" ]; then
   echo "Error; found 0 covering edit files."
   exit 1

--- a/dynamometer-workload/src/main/bash/parse-start-timestamp.sh
+++ b/dynamometer-workload/src/main/bash/parse-start-timestamp.sh
@@ -28,7 +28,7 @@ fi
 # try to find the edit logs whose transaction range covers the txid from the fsimage
 # first find the first txid which is greater or equal to the fsimage txid
 ending_txid=`ls -1 ${edits_dir} | grep -E "^edits_[[:digit:]]+-[[:digit:]]+\$" | \
-    awk -v t="$tmp_txid" -F'-' '{if ($2 >= t) {print $2}}' | head -1`
+    awk -v t="$image_txid" -F'-' '{if ($2 >= t) {print $2}}' | head -1`
 if [ -z "$ending_txid" ]; then
   echo "Error; found 0 covering edit files."
   exit 1

--- a/dynamometer-workload/src/main/bash/parse-start-timestamp.sh
+++ b/dynamometer-workload/src/main/bash/parse-start-timestamp.sh
@@ -25,12 +25,21 @@ else
   edits_dir="`pwd`"
 fi
 
-edits_file_count=`ls -1 ${edits_dir} | grep -E "^edits_[[:digit:]]+-0*$image_txid\$" | wc -l`
+# try to find the edit logs whose transaction range covers the txid from the fsimage
+# first find the first txid which is greater or equal to the fsimage txid
+ending_txid=`ls -1 ${edits_dir} | grep -E "^edits_[[:digit:]]+-[[:digit:]]+\$" | cut -d'-' -f 2 | \
+    awk -v t="$image_txid" {'if ($1 >= t) {print $1}'} | head -1`
+if [ -z "$ending_txid" ]; then
+  echo "Error; found 0 covering edit files."
+  exit 1
+fi
+# then grep the file ending with the ending_txid, exit if duplicated edits exist
+edits_file_count=`ls -1 ${edits_dir} | grep -E "^edits_[[:digit:]]+-0*$ending_txid\$" | wc -l`
 if [ "$edits_file_count" != 1 ]; then
   echo "Error; found $edits_file_count matching edit files."
   exit 1
 fi
-edits_file=`ls -1 ${edits_dir} | grep -E "^edits_[[:digit:]]+-0*$image_txid\$"`
+edits_file=`ls -1 ${edits_dir} | grep -E "^edits_[[:digit:]]+-0*$ending_txid\$"`
 
 awk_script='/TIMESTAMP/ { line=$0 } \
       END { match(line, />([[:digit:]]+)</, output); print output[1] }'


### PR DESCRIPTION
Sometimes the edit logs doesn't end exactly with the txid from fsimage, so we need to find the proper range which covers this id and thus to pick the right edit log