### PR TITLE
Ignore fsimage entries outside of the INodeSection when parsing XML.

### DIFF
--- a/dynamometer-blockgen/src/main/java/com/linkedin/dynamometer/blockgenerator/XMLParser.java
+++ b/dynamometer-blockgen/src/main/java/com/linkedin/dynamometer/blockgenerator/XMLParser.java
@@ -7,6 +7,7 @@ package com.linkedin.dynamometer.blockgenerator;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -52,6 +53,13 @@ class XMLParser {
    * @return {@code BlockInfo}s for any blocks found.
    */
   List<BlockInfo> parseLine(String line) throws IOException {
+    if (currentState == State.DEFAULT) {
+      if (line.contains("<INodeSection>")) {
+        transitionTo(State.INODE_SECTION);
+      } else {
+        return Collections.emptyList();
+      }
+    }
     if (line.contains("<inode>")) {
       transitionTo(State.INODE);
     }
@@ -78,6 +86,9 @@ class XMLParser {
       blockInfos.add(new BlockInfo(id, gs, size, currentReplication));
     }
     if (line.contains("</inode>")) {
+      transitionTo(State.INODE_SECTION);
+    }
+    if (line.contains("</INodeSection>")) {
       transitionTo(State.DEFAULT);
     }
     return blockInfos;
@@ -113,16 +124,18 @@ class XMLParser {
 
   private enum State {
     DEFAULT,
+    INODE_SECTION,
     INODE,
     FILE,
     FILE_WITH_REPLICATION;
 
     private final Set<State> allowedTransitions = new HashSet<>();
     static {
-      DEFAULT.addTransitions(DEFAULT, INODE);
-      INODE.addTransitions(DEFAULT, FILE);
-      FILE.addTransitions(DEFAULT, FILE_WITH_REPLICATION);
-      FILE_WITH_REPLICATION.addTransitions(DEFAULT);
+      DEFAULT.addTransitions(DEFAULT, INODE_SECTION);
+      INODE_SECTION.addTransitions(DEFAULT, INODE);
+      INODE.addTransitions(INODE_SECTION, FILE);
+      FILE.addTransitions(INODE_SECTION, FILE_WITH_REPLICATION);
+      FILE_WITH_REPLICATION.addTransitions(INODE_SECTION);
     }
 
     private void addTransitions(State... nextState) {

--- a/dynamometer-blockgen/src/test/java/com/linkedin/dynamometer/blockgenerator/TestXMLParser.java
+++ b/dynamometer-blockgen/src/test/java/com/linkedin/dynamometer/blockgenerator/TestXMLParser.java
@@ -33,7 +33,8 @@ public class TestXMLParser {
         "<inode><type>FILE</type>",
         "<replication>12</replication>",
         "<blocks><block><id>13</id><genstamp>14</genstamp><numBytes>15</numBytes></block>",
-        "</inode>"
+        "</inode>",
+        "</INodeSection>"
     };
 
     Map<BlockInfo, Short> expectedBlockCount = new HashMap<>();
@@ -51,6 +52,25 @@ public class TestXMLParser {
 
     for (Map.Entry<BlockInfo, Short> expect : expectedBlockCount.entrySet()) {
       assertEquals(expect.getValue(), actualBlockCount.get(expect.getKey()));
+    }
+  }
+
+  @Test
+  public void testNonInodeSectionIgnored() throws Exception {
+    String[] lines = {
+        "<INodeSection>",
+        "</INodeSection>",
+        "<OtherSection>",
+        "<inode><id>1</id><type>FILE</type><name>fake-file</name><replication>1</replication>",
+        "<blocks><block><id>2</id><genstamp>1</genstamp><numBytes>1</numBytes></block>",
+        "</inode>",
+        "<replication>3</replication>",
+        "</OtherSection>"
+    };
+
+    XMLParser parser = new XMLParser();
+    for (String line : lines) {
+      assertTrue((parser.parseLine(line).isEmpty()));
     }
   }
 }


### PR DESCRIPTION
This fixes the issue described in PR #77 regarding improper parsing of the FSImage XML when the CacheManagerSection is present.