### PR TITLE
Closes #60. Fix issues with the start-workload.sh script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ via logging when the Dyno-NN has exited safemode and is ready for use.
 At this point, a workload job (map-only MapReduce job) can be launched, e.g.:
 ```
 ./bin/start-workload.sh
-    -Dauditreplay.input-path hdfs:///dyno/audit_logs/
-    -Dauditreplay.num-threads 50
+    -Dauditreplay.input-path=hdfs:///dyno/audit_logs/
+    -Dauditreplay.num-threads=50
     -nn_uri hdfs://namenode_address:port/
     -start_time_offset 5m
     -mapper_class_name AuditReplayMapper

--- a/dynamometer-workload/src/main/java/com/linkedin/dynamometer/workloadgenerator/WorkloadDriver.java
+++ b/dynamometer-workload/src/main/java/com/linkedin/dynamometer/workloadgenerator/WorkloadDriver.java
@@ -131,15 +131,24 @@ public class WorkloadDriver extends Configured implements Tool {
   }
 
   private Class<? extends WorkloadMapper> getMapperClass(String className) throws ClassNotFoundException {
-    if (!className.contains(".")) {
-      className = WorkloadDriver.class.getPackage().getName() + "." + className;
+    String[] potentialQualifiedClassNames = {
+        WorkloadDriver.class.getPackage().getName() + "." + className,
+        AuditReplayMapper.class.getPackage().getName() + "." + className,
+        className
+    };
+    for (String qualifiedClassName : potentialQualifiedClassNames) {
+      Class<?> mapperClass;
+      try {
+        mapperClass = getConf().getClassByName(qualifiedClassName);
+      } catch (ClassNotFoundException cnfe) {
+        continue;
+      }
+      if (!WorkloadMapper.class.isAssignableFrom(mapperClass)) {
+        throw new IllegalArgumentException(className + " is not a subclass of " + WorkloadMapper.class.getCanonicalName());
+      }
+      return (Class<? extends WorkloadMapper>) mapperClass;
     }
-    Class<?> mapperClass = getConf().getClassByName(className);
-    if (!WorkloadMapper.class.isAssignableFrom(mapperClass)) {
-      throw new IllegalArgumentException(className + " is not a subclass of " +
-          WorkloadMapper.class.getCanonicalName());
-    }
-    return (Class<? extends WorkloadMapper>) mapperClass;
+    throw new IllegalArgumentException("Unable to find workload mapper class: " + className);
   }
 
   private String getMapperUsageInfo(String mapperClassName) throws ClassNotFoundException,


### PR DESCRIPTION
This is my approach, superceding PR #62. It is a bit more lenient with where it checks for implementations of `WorkloadMapper` implementations, and is able to find both `AuditReplayMapper` and `CreateFileMapper`.