### PR TITLE
Fix bintray config, moving user config to top level

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -10,10 +10,9 @@ allprojects {
    plugins.withId("com.shipkit.bintray") {
        bintray {
            key = System.getenv("BINTRAY_API_KEY")
-
+           user = System.getenv("BINTRAY_USER")
            pkg {
                repo = 'maven'
-               user = System.getenv("BINTRAY_USER")
                userOrg = 'linkedin'
                name = 'dynamometer'
                licenses = ['BSD 2-Clause']


### PR DESCRIPTION
The deploy step for Bintray recently failed: https://travis-ci.org/linkedin/dynamometer/jobs/499541233
```
[performRelease] * What went wrong:
[performRelease] Missing 'bintray.user' value.
[performRelease]   Please configure Bintray extension.
[performRelease] 
```
Based off of this guide:https://github.com/bintray/gradle-bintray-plugin#step-3-add-the-bintray-configuration-closure-to-your-buildgradle-file
I think that the `user` property is supposed to be at the top-level of the `bintray` closure as opposed to within the `pkg` closure.