### PR TITLE
Workaround for bintray user issue

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -6,8 +6,8 @@ shipkit {
    gitHub.writeAuthToken = System.getenv("GH_WRITE_TOKEN")
 }
 
-allprojects {
-   plugins.withId("com.shipkit.bintray") {
+subprojects {
+   afterEvaluate {
        bintray {
            key = System.getenv("BINTRAY_API_KEY")
            user = System.getenv("BINTRAY_USER")


### PR DESCRIPTION
The problem is that Gradle does not seem to be executing the closure under plugins.withId("com.shipkit.bintray"). I'm digging into this. In the meantime, we can workaround with 'afterEvaluate'