### PR TITLE
Make XML parsing error message more explicit

### DIFF
--- a/dynamometer-blockgen/src/main/java/com/linkedin/dynamometer/blockgenerator/XMLParser.java
+++ b/dynamometer-blockgen/src/main/java/com/linkedin/dynamometer/blockgenerator/XMLParser.java
@@ -77,7 +77,7 @@ class XMLParser {
       long size = Long.parseLong(blockMatcher.group(3));
       blockInfos.add(new BlockInfo(id, gs, size, currentReplication));
     }
-    if (line.contains("</inode>")) {
+    if (line.endsWith("</inode>")) {
       transitionTo(State.DEFAULT);
     }
     return blockInfos;

--- a/dynamometer-blockgen/src/main/java/com/linkedin/dynamometer/blockgenerator/XMLParser.java
+++ b/dynamometer-blockgen/src/main/java/com/linkedin/dynamometer/blockgenerator/XMLParser.java
@@ -77,7 +77,7 @@ class XMLParser {
       long size = Long.parseLong(blockMatcher.group(3));
       blockInfos.add(new BlockInfo(id, gs, size, currentReplication));
     }
-    if (line.endsWith("</inode>")) {
+    if (line.contains("</inode>")) {
       transitionTo(State.DEFAULT);
     }
     return blockInfos;

--- a/dynamometer-blockgen/src/main/java/com/linkedin/dynamometer/blockgenerator/XMLParserMapper.java
+++ b/dynamometer-blockgen/src/main/java/com/linkedin/dynamometer/blockgenerator/XMLParserMapper.java
@@ -49,7 +49,13 @@ public class XMLParserMapper extends Mapper<LongWritable, Text, IntWritable, Blo
   public void map(LongWritable lineNum, Text line,
       Mapper<LongWritable, Text, IntWritable, BlockInfo>.Context context)
       throws IOException, InterruptedException {
-    List<BlockInfo> blockInfos = parser.parseLine(line.toString());
+    List<BlockInfo> blockInfos;
+    try {
+      blockInfos = parser.parseLine(line.toString());
+    } catch (IOException e) {
+      throw new IOException(String.format("IOException %s happened for line %s", e.getMessage(), line));
+    }
+
     for (BlockInfo blockInfo : blockInfos) {
       for (short i = 0; i < blockInfo.getReplication(); i++) {
         context.write(new IntWritable((blockIndex + i) % numDataNodes), blockInfo);


### PR DESCRIPTION
There are two points in this pr:
1) when parsing the xml INodeSection, the state machine actually requires that </inode> must be the ending of a line, otherwise other states will kick in thus will result in errors.

2) expose the actual line under parsing in the exceptions for easier debugging, otherwise there is no clue what happened.