### PR TITLE
Closes #99. Document supported versions and improve compatibility with 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ jobs:
       script: "./gradlew build -x test"
     - stage: test
       script: "./gradlew test --stacktrace --info -Ddyno.hadoop.bin.version=${HADOOP_VERSION}"
-      env: HADOOP_VERSION=2.7.6
+      env: HADOOP_VERSION=2.7.7
     - stage: test
       script: "./gradlew test --stacktrace --info -Ddyno.hadoop.bin.version=${HADOOP_VERSION}"
-      env: HADOOP_VERSION=2.8.4
+      env: HADOOP_VERSION=2.8.5
     - stage: deploy
       script: "./gradlew build -s && ./gradlew ciPerformRelease"
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Dynamometer [![Build Status](https://travis-ci.org/linkedin/dynamometer.svg?branch=master)](https://travis-ci.org/linkedin/dynamometer)
 
+## Dynamometer in Hadoop
+
+Please be aware that Dynamometer has now been committed into Hadoop itself in the JIRA ticket [HDFS-12345](https://issues.apache.org/jira/browse/HDFS-12345). It is located under the `hadoop-tools/hadoop-dynamometer` submodule. This GitHub project will continue to be maintained for testing
+against the `2.x` release line of Hadoop, but all versions of Dynamometer which work with Hadoop 3 will
+only appear in Hadoop, and future development will primarily occur there.
+
 ## Overview
 
 Dynamometer is a tool to performance test Hadoop's HDFS NameNode. The intent is to provide a
@@ -25,6 +31,15 @@ top of which Dynamometer is run.
 
 Dynamometer is based around YARN applications, so an existing YARN cluster will be required for execution.
 It also requires an accompanying HDFS instance to store some temporary files for communication.
+
+Please be aware that Dynamometer makes certain assumptions about HDFS, and thus only works with certain
+versions. As discussed at the start of this README, this project only works with Hadoop 2; support for
+Hadoop 3 is introduced in the version of Dynamometer within the Hadoop repository. Below is a list of known
+supported versions of Hadoop which are compatible with Dynamometer:
+* Hadoop 2.7 starting at 2.7.4
+* Hadoop 2.8 starting at 2.8.4
+
+Hadoop 2.8.2 and 2.8.3 are compatible as a cluster version on which to run Dynamometer, but are not supported as a version-under-test.
 
 ## Building
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
   id "org.shipkit.java" version "2.1.3"
 }
 
-def hadoopVersion = '2.7.5'
+def hadoopVersion = '2.7.7'
 ext.deps = [
   hadoop: [
     hdfs: "org.apache.hadoop:hadoop-hdfs:${hadoopVersion}",

--- a/dynamometer-infra/src/main/java/com/linkedin/dynamometer/SimulatedMultiStorageFSDataset.java
+++ b/dynamometer-infra/src/main/java/com/linkedin/dynamometer/SimulatedMultiStorageFSDataset.java
@@ -325,6 +325,10 @@ public class SimulatedMultiStorageFSDataset extends SimulatedFSDataset {
     public boolean isOnTransientStorage() {
       return false;
     }
+
+    public OutputStream createRestartMetaStream() throws IOException {
+      return null;
+    }
   }
 
   /**
@@ -509,7 +513,6 @@ public class SimulatedMultiStorageFSDataset extends SimulatedFSDataset {
       return false;
     }
 
-    @Override
     public void reserveSpaceForRbw(long bytesToReserve) {
     }
 
@@ -537,6 +540,12 @@ public class SimulatedMultiStorageFSDataset extends SimulatedFSDataset {
     public byte[] loadLastPartialChunkChecksum(
         File blockFile, File metaFile) throws IOException {
       return null;
+    }
+
+    public void reserveSpaceForReplica(long l) {
+    }
+
+    public void releaseLockedMemory(long l) {
     }
   }
 
@@ -1308,7 +1317,6 @@ public class SimulatedMultiStorageFSDataset extends SimulatedFSDataset {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<FsVolumeSpi> getVolumes() {
     throw new UnsupportedOperationException();
   }
@@ -1344,7 +1352,6 @@ public class SimulatedMultiStorageFSDataset extends SimulatedFSDataset {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<FinalizedReplica> getFinalizedBlocksOnPersistentStorage(String bpid) {
     throw new UnsupportedOperationException();
   }


### PR DESCRIPTION
Document that only the 2.7 and 2.8 line are currently supported, and specify which patch versions are supported. Improve the compatibility with the 2.8 release line as a host cluster.